### PR TITLE
Add digital products store

### DIFF
--- a/src/components/DigitalProductCard.jsx
+++ b/src/components/DigitalProductCard.jsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { Card, CardHeader, CardTitle, CardContent, CardFooter } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { ShoppingCart } from 'lucide-react';
+import { motion } from 'framer-motion';
+
+const formatPrice = (price) => {
+  return `$${price}`;
+};
+
+const DigitalProductCard = ({ product }) => {
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 20 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true, amount: 0.2 }}
+      transition={{ duration: 0.4 }}
+    >
+      <Card className="flex flex-col h-full bg-card/80 backdrop-blur-sm">
+        {product.label && (
+          <div className="absolute top-2 left-2 bg-primary text-primary-foreground text-xs font-semibold px-2 py-1 rounded">
+            {product.label}
+          </div>
+        )}
+        <CardHeader className="p-4">
+          <img-replace src={product.image} alt={product.title} className="w-full h-40 object-cover rounded" />
+          <CardTitle className="mt-4 text-lg font-bold text-foreground line-clamp-2">
+            {product.title}
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="flex-grow p-4">
+          <p className="text-sm text-muted-foreground line-clamp-3 mb-4">{product.description}</p>
+          {product.discountPrice ? (
+            <div className="space-x-2 rtl:space-x-reverse">
+              <span className="line-through text-muted-foreground text-sm">{formatPrice(product.price)}</span>
+              <span className="text-xl font-bold text-primary">{formatPrice(product.discountPrice)}</span>
+            </div>
+          ) : (
+            <span className="text-xl font-bold text-primary">{formatPrice(product.price)}</span>
+          )}
+        </CardContent>
+        <CardFooter className="p-4 mt-auto">
+          <Button size="sm" className="w-full bg-gradient-to-r from-primary to-purple-600 hover:from-primary/90 hover:to-purple-600/90 text-primary-foreground">
+            <ShoppingCart className="w-4 h-4 mr-2 rtl:ml-2" /> Buy Now
+          </Button>
+        </CardFooter>
+      </Card>
+    </motion.div>
+  );
+};
+
+export default DigitalProductCard;

--- a/src/components/DigitalStore.jsx
+++ b/src/components/DigitalStore.jsx
@@ -1,0 +1,80 @@
+import React, { useState } from 'react';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import DigitalProductCard from '@/components/DigitalProductCard';
+import { motion } from 'framer-motion';
+
+const products = [
+  {
+    id: 'theme1',
+    title: 'Modern Business Theme',
+    description: 'Responsive WordPress theme perfect for startups and agencies.',
+    price: 49,
+    discountPrice: 29,
+    category: 'Themes',
+    image: 'https://images.unsplash.com/photo-1502882700264-02ff9277f1d9?auto=format&fit=crop&w=800&q=60',
+    label: 'Sale'
+  },
+  {
+    id: 'plugin1',
+    title: 'SEO Booster Plugin',
+    description: 'Improve your rankings with automated SEO suggestions.',
+    price: 39,
+    discountPrice: null,
+    category: 'Plugins',
+    image: 'https://images.unsplash.com/photo-1498050108023-c5249f4df085?auto=format&fit=crop&w=800&q=60'
+  },
+  {
+    id: 'system1',
+    title: 'Invoice Manager System',
+    description: 'Manage invoices and clients with this lightweight web app.',
+    price: 99,
+    discountPrice: 79,
+    category: 'Systems',
+    image: 'https://images.unsplash.com/photo-1587620962725-abab7fe55159?auto=format&fit=crop&w=800&q=60',
+    label: 'New'
+  },
+  {
+    id: 'app1',
+    title: 'Task Tracker Desktop App',
+    description: 'Windows application to track tasks and productivity.',
+    price: 59,
+    discountPrice: null,
+    category: 'Apps',
+    image: 'https://images.unsplash.com/photo-1587825140807-06b3f33c37e7?auto=format&fit=crop&w=800&q=60'
+  }
+];
+
+const categories = ['All', 'Themes', 'Plugins', 'Systems', 'Apps'];
+
+const DigitalStore = () => {
+  const [category, setCategory] = useState('All');
+
+  const filtered = category === 'All' ? products : products.filter(p => p.category === category);
+
+  return (
+    <motion.section className="py-16" initial={{ opacity: 0 }} whileInView={{ opacity: 1 }} viewport={{ once: true }}>
+      <div className="container mx-auto px-4">
+        <div className="flex items-center justify-between mb-8">
+          <h2 className="text-3xl font-bold text-foreground">Digital Products Store</h2>
+          <Select value={category} onValueChange={setCategory}>
+            <SelectTrigger className="w-[180px]">
+              <SelectValue placeholder="Category" />
+            </SelectTrigger>
+            <SelectContent>
+              {categories.map(cat => (
+                <SelectItem key={cat} value={cat}>{cat}</SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+          {filtered.map(product => (
+            <DigitalProductCard key={product.id} product={product} />
+          ))}
+        </div>
+      </div>
+    </motion.section>
+  );
+};
+
+export default DigitalStore;

--- a/src/pages/ProductsPage.jsx
+++ b/src/pages/ProductsPage.jsx
@@ -3,7 +3,8 @@ import { useTranslation } from 'react-i18next';
 import { Helmet } from 'react-helmet-async';
 import { motion } from 'framer-motion';
 import { Package } from 'lucide-react';
-import ServicesGrid from '@/components/ServicesGrid'; // Re-using for product display
+import ServicesGrid from '@/components/ServicesGrid';
+import DigitalStore from '@/components/DigitalStore';
 
 const ProductsPage = () => {
   const { t } = useTranslation();
@@ -31,10 +32,7 @@ const ProductsPage = () => {
       
       <ServicesGrid />
 
-      <section className="mt-16 text-center">
-        <h2 className="text-3xl font-bold mb-4 text-foreground">{t('comingSoon')}</h2>
-        <p className="text-lg text-muted-foreground">{t('comingSoonDetail')}</p>
-      </section>
+      <DigitalStore />
 
     </motion.div>
   );


### PR DESCRIPTION
## Summary
- add `DigitalProductCard` and `DigitalStore` components
- integrate store into Products page

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6844225956948327b4f9a27d76a53bec